### PR TITLE
Remove Content-Length

### DIFF
--- a/library/Exakat/Graph/Gremlin3.php
+++ b/library/Exakat/Graph/Gremlin3.php
@@ -160,8 +160,7 @@ GREMLIN;
         $ch = curl_init();
 
         //set the url, number of POST vars, POST data
-        $headers = array( 'Content-Length: '.strlen($getString),
-                          'User-Agent: exakat',
+        $headers = array('User-Agent: exakat',
                           'X-Stream: true');
         if (!empty($this->neo4j_auth)) {
             $headers[] = 'Authorization: Basic '.$this->neo4j_auth;


### PR DESCRIPTION
Removing content length for the get curl request. RFC 2616 says not to do content lenght for a get request